### PR TITLE
Update bundler to fix Travis-ci build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,2 @@
+before_install: gem install bundler
 script: bundle exec rspec


### PR DESCRIPTION
This PR is to fix Travis build error: 
```
NoMethodError: undefined method `spec' for nil:NilClass
```