### PR TITLE
Ignore original_db_key when filtering model attributes

### DIFF
--- a/lib/tush/model_wrapper.rb
+++ b/lib/tush/model_wrapper.rb
@@ -49,15 +49,12 @@ module Tush
     end
 
     def filtered_model_attributes
-      model_attributes.delete_if do |attribute, value|
-        not model_class.columns_hash.keys.include?(attribute)
+      model_attributes.clone.delete_if do |attribute, value|
+        !model_class.columns_hash.keys.include?(attribute) || attribute == original_db_key
       end
     end
 
     def create_without_validation_and_callbacks
-      attributes = model_attributes.clone
-      attributes.delete(original_db_key)
-
       copy = model_class.new(filtered_model_attributes)
       copy.sneaky_save
       copy.reload

--- a/spec/model_wrapper_spec.rb
+++ b/spec/model_wrapper_spec.rb
@@ -189,4 +189,14 @@ describe Tush::ModelWrapper do
 
   end
 
+  describe '#filtered_model_attributes' do
+    it "should remove the object's original_db_key" do
+      jimmy = Jimmy.create!(ray_id: 3)
+      wrapper = Tush::ModelWrapper.new(model: jimmy)
+
+      expect(jimmy).to have_attribute(:id)
+      expect(wrapper.filtered_model_attributes).to eq({ 'ray_id' => 3 })
+    end
+  end
+
 end


### PR DESCRIPTION
This removes the `original_db_key` when filtering attributes for `create_without_validation_and_callbacks`, which happens in cases where the model does not have a `custom_create` method set.

When/if `id` is not protected on the model, assigning it here may attempt to write the new object with an id that already exists, leading to a `ActiveRecord::RecordNotUnique: PG::UniqueViolation` on the model's primary key (raised using `sneaky_save!` which blows up on the insert [here](https://github.com/einzige/sneaky-save/blob/master/lib/sneaky-save.rb#L56)).

Related commits for context:
- Addition: [`create_without_validation_and_callbacks`](https://github.com/3dna/tush/commit/7f459914c85178729b40cd7e07671de6de188b81)
- Addition: [filtering model attributes](https://github.com/3dna/tush/commit/587025dfbed78fab3a7bb0f517f706be82945ab9) 
